### PR TITLE
fix build with xcodebuild 11.5

### DIFF
--- a/lib/compile-xcodeproj.js
+++ b/lib/compile-xcodeproj.js
@@ -26,13 +26,14 @@ module.exports = function compileNib(loader, projectPath, outputPath, cb) {
     path.dirname(projectPath),
   );
   
-  let projectFile = projectPath + '/project.xcworkspace';
+  const projectFile = path.join(projectPath, project.xcworkspace);
+  const schema = path.basename(projectPath, path.extname(projectPath))
   
   execFile(
     'xcodebuild',
     ['build', '-workspace', 
-    fs.existsSync(projectFile) ? projectFile: projectPath,
-    '-scheme', path.basename(projectPath, path.extname(projectPath)), '-configuration', 'release', '-quiet', '-derivedDataPath', outputPath, 'COMMAND_LINE_BUILD=1'], { encoding: 'utf8' },
+    fs.existsSync(projectFile) ? projectFile : projectPath,
+    '-scheme', schema, '-configuration', 'release', '-quiet', '-derivedDataPath', outputPath, 'COMMAND_LINE_BUILD=1'], { encoding: 'utf8' },
     error => cb(error),
   );
 };

--- a/lib/compile-xcodeproj.js
+++ b/lib/compile-xcodeproj.js
@@ -25,10 +25,14 @@ module.exports = function compileNib(loader, projectPath, outputPath, cb) {
     loader.addDependency ? loader.addDependency.bind(loader) : () => {},
     path.dirname(projectPath),
   );
-
+  
+  let projectFile = projectPath + '/project.xcworkspace';
+  
   execFile(
     'xcodebuild',
-    ['build', '-workspace', projectPath, '-scheme', path.basename(projectPath, path.extname(projectPath)), '-configuration', 'release', '-quiet', '-derivedDataPath', outputPath, 'COMMAND_LINE_BUILD=1'], { encoding: 'utf8' },
+    ['build', '-workspace', 
+    fs.existsSync(projectFile) ? projectFile: projectPath,
+    '-scheme', path.basename(projectPath, path.extname(projectPath)), '-configuration', 'release', '-quiet', '-derivedDataPath', outputPath, 'COMMAND_LINE_BUILD=1'], { encoding: 'utf8' },
     error => cb(error),
   );
 };


### PR DESCRIPTION
work with Xcode 11.5 get an error:

`
Module build failed (from ./node_modules/@skpm/xcodeproj-loader/lib/index.js):
Error: Error compiling Xcode project: Command failed: xcodebuild build -workspace /../src/Navi/Navi.xcodeproj -scheme Navi -configuration release -quiet -derivedDataPath /../node_modules/@skpm/xcodeproj-loader/.cache COMMAND_LINE_BUILD=1
xcodebuild: error: '/../src/Navi/Navi.xcodeproj' is not a workspace file.

    at error (/../node_modules/@skpm/xcodeproj-loader/lib/index.js:124:11)
    at error (/../node_modules/@skpm/xcodeproj-loader/lib/compile-xcodeproj.js:32:14)
    at ChildProcess.exithandler (child_process.js:301:5)
    at ChildProcess.emit (events.js:198:13)
    at maybeClose (internal/child_process.js:982:16)
    at Socket.stream.socket.on (internal/child_process.js:389:11)
    at Socket.emit (events.js:198:13)
    at Pipe._handle.close (net.js:606:12)
 @ ./src/script.js 2:16-64
`

xcodebuild option [workspace] should be /../src/Navi/Navi.xcodeproj/project.xcworkspace !

And can not change require target to solve this problem , such as:
`
const framework = require('./Navi/Navi.xcodeproj/project.pbxproj/project.xcworkspace');
`
would get another error.

so have to change the build option by this commit.