### PR TITLE
fix: fix stdout maxBuffer exceeded error

### DIFF
--- a/lib/compile-xcodeproj.js
+++ b/lib/compile-xcodeproj.js
@@ -44,7 +44,10 @@ module.exports = function compileNib(loader, projectPath, outputPath, cb) {
       outputPath,
       'COMMAND_LINE_BUILD=1',
     ],
-    { encoding: 'utf8' },
+    { 
+      encoding: 'utf8',
+      maxBuffer: 200 * 1024 * 1024, // default 200 * 1024
+    },
     (error) => cb(error),
   );
 };


### PR DESCRIPTION
Fix an error that can occur when compling big xcode project.（> 200k）

> node.js Error: stdout maxBuffer exceeded at xcodeproj-loader/lib/compile-xcodeproj.js
